### PR TITLE
remove incorrect type hint

### DIFF
--- a/python/needle/ops/ops_mathematic.py
+++ b/python/needle/ops/ops_mathematic.py
@@ -328,7 +328,7 @@ class Stack(TensorOp):
         """
         self.axis = axis
 
-    def compute(self, args: TensorTuple) -> Tensor:
+    def compute(self, args):
         ### BEGIN YOUR SOLUTION
         raise NotImplementedError()
         ### END YOUR SOLUTION


### PR DESCRIPTION
This is a fix for issue #11 , where the `compute` method in class `Stack` should accept a collection of `NDArray` and return a `NDArray`.